### PR TITLE
fix: remove dependency on clojure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ The distance function returns a map with the discrete frechet distance (`:dist`)
 and the coupling sequence (`:couple`). The Euclidean distance is used as the
 default metric, but you can use an arbitrary distance function if you pass it
 as third argument.
+
 ```Clojure
 (ns example.core
-  (:require [carocad.frechet.core :as frechet]))
+  (:require [carocad.frechet :as frechet]))
 
-  (frechet/distance [[1 2] [3 4]]
-                    [[5 6] [7 8] [9 0]])
+(frechet/distance [[1 2] [3 4]]
+                  [[5 6] [7 8] [9 0]])
 ;;=> {:dist 7.211102550927978, :couple ([0 0] [1 1] [1 2])}
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject net.clojars.carocad/frechet "0.11.2"
+(defproject net.clojars.carocad/frechet "0.12.0"
   :description "Calculate the discrete Frechet distance between two polygonal curves"
   :url "https://github.com/carocad/frechet-dist"
   :license {:name "LGPL v3"
             :url  "https://github.com/carocad/frechet-dist/blob/master/LICENSE"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
                  [net.mikera/vectorz-clj "0.43.1" :exclusions [org.clojure/clojure]]]
   :profiles {:dev {:dependencies [[criterium "0.4.5"]
                                   [org.clojure/test.check "0.10.0"]]

--- a/src/carocad/frechet.clj
+++ b/src/carocad/frechet.clj
@@ -1,4 +1,4 @@
-(ns carocad.frechet.core
+(ns carocad.frechet
   (:require [clojure.core.matrix :as matrix]
             [carocad.frechet.partial :as partial]
             [carocad.frechet.shared :as common]

--- a/test/carocad/frechet/benchmark.clj
+++ b/test/carocad/frechet/benchmark.clj
@@ -6,7 +6,7 @@
             [criterium.core :as criterium]
             [clojure.java.io :as io]
             [clojure.edn :as edn]
-            [carocad.frechet.core :as frechet]
+            [carocad.frechet :as frechet]
             [clojure.core.matrix :as matrix]
             [carocad.frechet.sampler :as sampler])
   (:import (java.io PushbackReader)))

--- a/test/carocad/frechet/core_test.clj
+++ b/test/carocad/frechet/core_test.clj
@@ -1,5 +1,5 @@
 (ns carocad.frechet.core-test
-  (:require [carocad.frechet.core :as frechet]
+  (:require [carocad.frechet :as frechet]
             ;[clojure.test.check :as tc]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]

--- a/test/carocad/frechet/partial_test.clj
+++ b/test/carocad/frechet/partial_test.clj
@@ -1,5 +1,5 @@
 (ns carocad.frechet.partial-test
-  (:require [carocad.frechet.core :as frechet]
+  (:require [carocad.frechet :as frechet]
             [clojure.test.check :as tc]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]

--- a/test/carocad/frechet/sampler_test.clj
+++ b/test/carocad/frechet/sampler_test.clj
@@ -1,5 +1,5 @@
 (ns carocad.frechet.sampler-test
-  (:require [carocad.frechet.core :as frechet]
+  (:require [carocad.frechet :as frechet]
             [carocad.frechet.sampler :as sampler]
             [clojure.core.matrix :as matrix]
             [clojure.test.check :as tc]


### PR DESCRIPTION
chore: rename namespace carocad.frechet.core to carocad.frechet